### PR TITLE
Misc fixes and updates

### DIFF
--- a/COPYING
+++ b/COPYING
@@ -1,0 +1,18 @@
+(C) Copyright 2003 A.M. Kuchling.  All Rights Reserved
+(C) Copyright 2004 A.M. Kuchling, Ralph Heinkel  All Rights Reserved
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of A.M. Kuchling and
+Ralph Heinkel not be used in advertising or publicity pertaining to
+distribution of the software without specific, written prior permission.
+
+A.M. KUCHLING, R.H. HEINKEL DISCLAIM ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS,
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/_sane.c
+++ b/_sane.c
@@ -1072,7 +1072,7 @@ SaneDev_arr_snap(SaneDevObject *self, PyObject *args)
 #ifdef WITH_NUMPY
   npy_intp numpy_shape[] = { p.lines, pixels_per_line, bfc};
   /* printf ("numpy shape %d x %d x %d  shape_dim %d\n", numpy_shape[0], numpy_shape[1], numpy_shape[2], bfc==1?2:3); */
-  if (!( pyArr = PyArray_SimpleNew(bfc==1?2:3, numpy_shape, arrType) )) 
+  if (!( pyArr = (PyArrayObject *)PyArray_SimpleNew(bfc==1?2:3, numpy_shape, arrType) )) 
 #elif defined WITH_NUMARRAY
       /* important: NumArray have indices like (y, x) !! */
   if (!(pyArr = NA_NewArray(NULL, arrType, 2, p.lines, pixels_per_line)))
@@ -1166,11 +1166,26 @@ SaneDev_arr_snap(SaneDevObject *self, PyObject *args)
   return (PyObject*) pyArr;
 }
 
+static PyObject *
+PySane_checkSaneArray(PyObject *self, PyObject *args)
+{
+  return Py_BuildValue("ssi", "checkSaneArray", ARRAY_SUPPORT_MSG, ARRAY_IMPORTED);
+}
+
 #else  
 static PyObject *
 SaneDev_arr_snap(SaneDevObject *self, PyObject *args)
-{    return PySane_Error( "Not compiled with array support (numpy or numarray");
-     }
+{
+  PyErr_SetString(ErrorObject, "Not compiled with array support (numpy or numarray)");
+  return NULL;
+}
+
+static PyObject *
+PySane_checkSaneArray(PyObject *self, PyObject *args)
+{
+  PyErr_SetString(ErrorObject, "Not compiled with array support (numpy or numarray)");
+  return NULL;
+}
 
 #endif /* WITH_NUMARRAY or WITH_NUMPY both defining ARRAY_SUPPORT */
 
@@ -1333,12 +1348,6 @@ PySane_OPTION_IS_SETTABLE(PyObject *self, PyObject *args)
     return NULL;
   cap=lg;
   return PyInt_FromLong( SANE_OPTION_IS_SETTABLE(cap));
-}
-
-static PyObject *
-PySane_checkSaneArray(PyObject *self, PyObject *args)
-{
-   return Py_BuildValue("ssi", "checkSaneArray", ARRAY_SUPPORT_MSG, ARRAY_IMPORTED);
 }
 
 /* List of functions defined in the module */

--- a/sane.py
+++ b/sane.py
@@ -9,15 +9,6 @@ __version__ = '2.0'
 __author__  = ['Andrew Kuchling', 'Ralph Heinkel']
 
 from PIL import Image
-
-#print "SANE :", __file__,  "  ..... call import _sane"
-#import sys
-#sys.path.append('./')
-import _sane 
-if not 'checkSaneArray' in dir(_sane) :
-    print "_BAD VERSION for_sane.so"
-    sys.exit(1)
-#print'checkSaneArray', _sane.checkSaneArray()
 from _sane import *
 
 TYPE_STR = { TYPE_BOOL:   "TYPE_BOOL",   TYPE_INT:    "TYPE_INT",

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 from distutils.core import setup, Extension
-
-PIL_BUILD_DIR   = '..'
-PIL_IMAGING_DIR = PIL_BUILD_DIR+'/libImaging'
+import distutils.sysconfig
+import os
 
 defs = []
 extra_compile_args =  []
@@ -18,9 +17,10 @@ except ImportError:
     pass
 
 sane = Extension('_sane',
-                 include_dirs = [PIL_IMAGING_DIR],
+                 include_dirs = [
+                     os.path.join(distutils.sysconfig.get_python_inc(), "Imaging")
+                 ],
                  libraries = ['sane'],
-                 library_dirs = [PIL_IMAGING_DIR],
                  define_macros = defs,
                  extra_compile_args = extra_compile_args,
                  sources = ['_sane.c'])


### PR DESCRIPTION
- Fix compilation without numpy which is broken, fix some warnings along the way.
- Remove some code which I presume was used for debugging in sane.py, it breaks bytecode compilation if installed in separate root.
- Fedora installs the Pillow headers in `/usr/include/pythonX.Y/Imaging`, add that path to the include dirs, and stop looking in the old `../libImaging` folder. Also remove `library_dirs = [PIL_IMAGING_DIR]`.
- Add a license file (taken from `_sane.c`).
