### PR TITLE
Remove compile time dependency on Pillow, now requires Pillow >=2.4.0

### DIFF
--- a/sane.py
+++ b/sane.py
@@ -237,7 +237,7 @@ class SaneDev:
         else:
             raise ValueError('got unknown "mode" from self.get_parameters()')
         im=Image.new(format, (xsize,ysize))
-        self.dev.snap( im.im.id, no_cancel )
+        self.dev.snap(dict(im.im.unsafe_ptrs), no_cancel )
         return im
 
     def scan(self):


### PR DESCRIPTION
@manisandro Please note that this is untested. I don't have the hardware for it. 

This PR removes the compile time dependency on the Pillow headers, replacing it with a stub struct that contains the portions of the image object that were used in _sane.c. The strict is filled using the same mechanism that Pillow uses to get pointers for the cffi based PyAccess module. 

 