### PR TITLE
Use container-based infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,8 +9,13 @@ python:
  - 3.3
  - 3.4
 
-install:
- - sudo apt-get install libsane-dev
+# Use container-based infrastructure
+sudo: false
+
+addons:
+  apt:
+    packages:
+    - libsane-dev
 
 # No tests: just check it can build and install
 script:


### PR DESCRIPTION
Fixes: #19 "Unable to locate libsane-dev on Travis CI".

With container-based infra, sudo is not allowed. However, packages can be whitelisted: https://docs.travis-ci.com/user/migrating-from-legacy/#How-do-I-install-APT-sources-and-packages%3F

And libsane-dev has been whitelisted by Travis: https://github.com/travis-ci/travis-ci/issues/3994

Builds also start up faster: https://docs.travis-ci.com/user/workers/container-based-infrastructure/