### PR TITLE
Add __next__ to _SaneIterator for Python 3

### DIFF
--- a/sane.py
+++ b/sane.py
@@ -128,6 +128,8 @@ class _SaneIterator:
                 raise
         return self.device.snap(True)
 
+    __next__ = next
+
 
 class SaneDev:
     """


### PR DESCRIPTION
In Python 3, an iterator is expected to have __next__ rather than next().