### PR TITLE
Drop support for EOL Python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,7 @@ language: python
 python:
  - pypy
  - pypy3
- - 2.6
  - 2.7
- - 3.2
- - 3.3
  - 3.4
  - 3.5
  - 3.6


### PR DESCRIPTION
Python 2.6 and 3.2-3-3 are EOL and no longer receive security updates by the core Python team.

https://en.wikipedia.org/wiki/CPython#Version_history
https://devguide.python.org/#status-of-python-branches
