### PR TITLE
Removed Python 3.4, moved Trusty jobs to Xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ matrix:
     - python: pypy3
       dist: trusty
     - python: 2.7
-    - python: 3.4
-      dist: trusty
     - python: 3.5
     - python: 3.6
     - python: 3.7

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,10 +19,8 @@ after_script:
 matrix:
   fast_finish: true
   include:
-    - python: pypy
-      dist: trusty
-    - python: pypy3
-      dist: trusty
+    - python: pypy2.7-6.0
+    - python: pypy3.5-6.0
     - python: 2.7
     - python: 3.5
     - python: 3.6


### PR DESCRIPTION
As with https://github.com/python-pillow/Pillow/pull/3596, Python 3.4 is EOL.

As in https://github.com/python-pillow/Pillow/pull/3765, Trusty is EOL this month. So this moves Trusty jobs to Xenial, also updating PyPy to 6.0.0.