### PR TITLE
Update Travis CI badge for .com

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Python SANE module 2.8.3
 ========================
 
-.. image:: https://api.travis-ci.org/python-pillow/Sane.svg
-    :target: https://travis-ci.org/python-pillow/Sane
+.. image:: https://travis-ci.com/python-pillow/Sane.svg?branch=master
+    :target: https://travis-ci.com/github/python-pillow/Sane
 
 Python SANE has been split from Python-Pillow as of version 2.7.0.
 


### PR DESCRIPTION
For https://github.com/python-pillow/Pillow/issues/5020.

Travis CI has migrated from https://travis-ci.org to https://travis-ci.com
