### PR TITLE
Switched from deprecated "setup.py install" to "pip install ."

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         shell: bash
         run: |
           python setup.py build
-          python setup.py install
+          python -m pip install .
 
       - name: Lint
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,8 +30,8 @@ jobs:
       - name: Test build and install
         shell: bash
         run: |
-          python setup.py build
-          python -m pip install .
+          python3 setup.py build
+          python3 -m pip install .
 
       - name: Lint
         shell: bash

--- a/README.rst
+++ b/README.rst
@@ -16,11 +16,11 @@ Build
 
 To build this module, make sure the sane development package is installed. Then, type::
 
-	python setup.py build
+	python3 setup.py build
 
 In order to install the module type::
 
-	python -m pip install .
+	python3 -m pip install .
 
 
 For some basic documentation please look at the file sanedoc.txt

--- a/README.rst
+++ b/README.rst
@@ -20,7 +20,7 @@ To build this module, make sure the sane development package is installed. Then,
 
 In order to install the module type::
 
-	python setup.py install
+	python -m pip install .
 
 
 For some basic documentation please look at the file sanedoc.txt


### PR DESCRIPTION
Replaces `setup.py install` with `pip install .`, as per https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html

Or actually, `python3 -m pip install .`, using `python3` to invoke pip so that it is clear that the pip being invoked is the one connected to `python3`. See https://github.com/python-pillow/Pillow/pull/4459.

I've also replaced `python setup.py build` with `python3 setup.py build`, to ensure that users are not using Python 2.