### PR TITLE
add sane.exit() to example

### DIFF
--- a/example.py
+++ b/example.py
@@ -89,3 +89,8 @@ im.save('test_numpy.png')
 # Close the device
 #
 dev.close()
+
+#
+# Exiting sane
+#
+sane.exit()


### PR DESCRIPTION
Currently if example is run without sane.exit(), I see the following error when script is ran next time:
`python _sane.error: Invalid argument`
Adding in sane.exit() avoids this error from happening on next run
Device: Brother DS-740D