### PR TITLE
Update packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
         os: [ubuntu-latest]
 
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v6
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Install dependencies
         run: |
+          sudo apt-get update
           sudo apt-get install libsane-dev
 
       # No tests: just check it can install


### PR DESCRIPTION
The 'Install dependencies' step of GitHub Actions has started failing - https://github.com/python-pillow/Sane/actions/runs/19264784188/job/55077868923#step:4:65
> E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?

So this PR adds `apt-get update`.