### PR TITLE
Allow pushing virtual buttons

### DIFF
--- a/_sane.c
+++ b/_sane.c
@@ -350,11 +350,11 @@ SaneDev_set_option(SaneDevObject *self, PyObject *args)
       ((char*)v)[d->size - 1] = 0;
       Py_DECREF(strobj);
       break;
-    case SANE_TYPE_BUTTON:
     case SANE_TYPE_GROUP:
-      PyErr_SetString(ErrorObject, "SANE_TYPE_BUTTON and SANE_TYPE_GROUP can't be set");
+      PyErr_SetString(ErrorObject, "SANE_TYPE_GROUP can't be set");
       free(v);
       return NULL;
+    case SANE_TYPE_BUTTON:
     }
 
   SANE_Int info = 0;

--- a/sane.py
+++ b/sane.py
@@ -196,8 +196,6 @@ class SaneDev:
             return
 
         opt = d['opt'][key]
-        if opt.type == _sane.TYPE_BUTTON:
-            raise AttributeError("Buttons don't have values: " + key)
         if opt.type == _sane.TYPE_GROUP:
             raise AttributeError("Groups don't have values: " + key)
         if not _sane.OPTION_IS_ACTIVE(opt.cap):


### PR DESCRIPTION
This then allows:

```
>>> import sane
>>> sane.init()
(16908289, 1, 2, 1)
>>> scanner=sane.open("test")
>>> scanner.enable_test_options = True
>>> scanner.button = True
[14:00:40.210873] [test] Yes! You pressed me!
```